### PR TITLE
newest n8n.io version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM node:14.15-alpine
 
-ARG N8N_VERSION=0.114.0
-
-RUN if [ -z "$N8N_VERSION" ] ; then echo "The N8N_VERSION argument is missing!" ; exit 1; fi
-
 # Update everything and install needed dependencies
 RUN apk add --update graphicsmagick tzdata git su-exec jq
 
@@ -13,7 +9,7 @@ USER root
 # Install n8n and the also temporary all the packages
 # it needs to build it correctly.
 RUN apk --update add --virtual build-dependencies python build-base ca-certificates && \
-    npm_config_user=root npm install -g full-icu n8n@${N8N_VERSION} && \
+    npm_config_user=root npm install -g full-icu n8n && \
     apk del build-dependencies
 
 # Install fonts

--- a/config.json
+++ b/config.json
@@ -21,7 +21,6 @@
   "ingress_port": 5678,
   "panel_icon": "mdi:gate-xor",
   "options": {
-    "ip": "0.0.0.0",
     "auth": false,
     "auth_username": "",
     "auth_password": "",
@@ -31,7 +30,6 @@
     "keyfile": "privkey.pem"
   },
   "schema": {
-    "ip": "str",
     "auth": "bool",
     "auth_username": "str?",
     "auth_password": "str?",

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Hass n8n",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "slug": "hass-n8n",
   "description": "Self host your n8n instance",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
@@ -18,6 +18,8 @@
     "5678/tcp": "n8n Web interface"
   },
   "ingress": true,
+  "ingress_port": 5678,
+  "panel_icon": "mdi:gate-xor",
   "options": {
     "auth": false,
     "auth_username": "",

--- a/config.json
+++ b/config.json
@@ -21,6 +21,7 @@
   "ingress_port": 5678,
   "panel_icon": "mdi:gate-xor",
   "options": {
+    "ip": "0.0.0.0",
     "auth": false,
     "auth_username": "",
     "auth_password": "",
@@ -30,6 +31,7 @@
     "keyfile": "privkey.pem"
   },
   "schema": {
+    "ip": "str",
     "auth": "bool",
     "auth_username": "str?",
     "auth_password": "str?",

--- a/config.json
+++ b/config.json
@@ -17,6 +17,7 @@
   "ports_description": {
     "5678/tcp": "n8n Web interface"
   },
+  "ingress": true,
   "options": {
     "auth": false,
     "auth_username": "",

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,6 +13,7 @@ mkdir -p "${N8N_PATH}/.n8n"
 # REQUIRED
     
 
+export N8N_LISTEN_ADDRESS="$(jq --raw-output '.ip // empty' $CONFIG_PATH)"
 export N8N_BASIC_AUTH_ACTIVE="$(jq --raw-output '.auth // empty' $CONFIG_PATH)"
 export N8N_BASIC_AUTH_USER="$(jq --raw-output '.auth_username // empty' $CONFIG_PATH)"
 export N8N_BASIC_AUTH_PASSWORD="$(jq --raw-output '.auth_password // empty' $CONFIG_PATH)"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,7 +13,6 @@ mkdir -p "${N8N_PATH}/.n8n"
 # REQUIRED
     
 
-export N8N_LISTEN_ADDRESS="$(jq --raw-output '.ip // empty' $CONFIG_PATH)"
 export N8N_BASIC_AUTH_ACTIVE="$(jq --raw-output '.auth // empty' $CONFIG_PATH)"
 export N8N_BASIC_AUTH_USER="$(jq --raw-output '.auth_username // empty' $CONFIG_PATH)"
 export N8N_BASIC_AUTH_PASSWORD="$(jq --raw-output '.auth_password // empty' $CONFIG_PATH)"


### PR DESCRIPTION
I've removed the version tag when installing n8n.
There is no option to update. For now you just would need to rebuild the Addon to get the latest version.
I've tried to add ingress to the addon since my server operates behind a proxy. Unfortunally I didn't got it to a working state. The n8n Server listens on 0.0.0.0 judging from the log. So Home Assistant tries to connect to that ip which is obviously not working. I've tried modifieing the n8n parameters to take an ip as well but with that I just got more errors.
I just need it for a very simple automation so this ist working enough for me. Maybe someone will trie to get it working.