### PR TITLE
feat: add support for installing external npm packages

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -27,6 +27,16 @@ List of the N8N environment variables. You can add as many environment variables
 
 All the available environment variables are available here : <https://docs.n8n.io/hosting/environment-variables/environment-variables/>
 
+#### Installing external packages
+
+In n8n you can add external node modules by setting the `NODE_FUNCTION_ALLOW_EXTERNAL` environment variable with the list of npm packages you need.
+
+For example, to install the `lodash` and the `moment` packages, in the UI, set the `env_vars_list` variable to:
+
+```txt
+NODE_FUNCTION_ALLOW_EXTERNAL: lodash,moment
+```
+
 ### Option: `auth` (required)
 
 Enable of disable the basic authentication in the web interface.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.n8n.io/n8nio/n8n:1.65.1
 USER root
-RUN apk add --no-cache --update jq bash
+RUN apk add --no-cache --update jq bash npm
 WORKDIR /data
 COPY docker-entrypoint.sh /tmp/docker-entrypoint.sh
 ENTRYPOINT ["bash", "/tmp/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,6 +26,18 @@ do
     export "$key"="$value"
     echo "exported ${key}=${value}"
 done
+
+# IF NODE_FUNCTION_ALLOW_EXTERNAL is set, install the required packages
+
+if [ -n "${NODE_FUNCTION_ALLOW_EXTERNAL}" ]; then
+    echo "Installing external packages..."
+    IFS=',' read -r -a packages <<< "${NODE_FUNCTION_ALLOW_EXTERNAL}"
+    for package in "${packages[@]}"
+    do
+        echo "Installing ${package}..."
+        npm install -g "${package}"
+    done
+fi
     
 export N8N_BASIC_AUTH_ACTIVE="$(jq --raw-output '.auth // empty' $CONFIG_PATH)"
 export N8N_BASIC_AUTH_USER="$(jq --raw-output '.auth_username // empty' $CONFIG_PATH)"


### PR DESCRIPTION
Added functionality to allow the installation of external npm packages by setting the `NODE_FUNCTION_ALLOW_EXTERNAL` environment variable. Updated the Dockerfile to include npm and modified the entrypoint script to handle package installation. This enhancement enables users to extend n8n with additional node modules as needed.