### PR TITLE
fix: allow overriding environment variables

### DIFF
--- a/n8n-entrypoint.sh
+++ b/n8n-entrypoint.sh
@@ -4,6 +4,20 @@ N8N_PATH="/data/n8n"
 
 mkdir -p "${N8N_PATH}/.n8n/.cache"
 
+. /app/export-ingress-variables.sh
+
+export GENERIC_TIMEZONE="$(jq --raw-output '.timezone // empty' $CONFIG_PATH)"
+export N8N_CMD_LINE="$(jq --raw-output '.cmd_line_args // empty' $CONFIG_PATH)"
+export N8N_USER_FOLDER="${N8N_PATH}"
+export N8N_PATH="${INGRESS_PATH}"
+export N8N_EDITOR_BASE_URL="${INGRESS_URL}"
+
+export N8N_RUNNERS_ENABLED=true
+export N8N_BASIC_AUTH_ACTIVE=false
+export N8N_HIRING_BANNER_ENABLED=false
+export N8N_PERSONALIZATION_ENABLED=false
+export N8N_SECURE_COOKIE=false
+
 #####################
 ## USER PARAMETERS ##
 #####################
@@ -37,20 +51,6 @@ if [ -n "${NODE_FUNCTION_ALLOW_EXTERNAL}" ]; then
         npm install -g "${package}"
     done
 fi
-
-. /app/export-ingress-variables.sh
-
-export GENERIC_TIMEZONE="$(jq --raw-output '.timezone // empty' $CONFIG_PATH)"
-export N8N_CMD_LINE="$(jq --raw-output '.cmd_line_args // empty' $CONFIG_PATH)"
-export N8N_USER_FOLDER="${N8N_PATH}"
-export N8N_PATH="${INGRESS_PATH}"
-export N8N_EDITOR_BASE_URL="${INGRESS_URL}"
-
-export N8N_RUNNERS_ENABLED=true
-export N8N_BASIC_AUTH_ACTIVE=false
-export N8N_HIRING_BANNER_ENABLED=false
-export N8N_PERSONALIZATION_ENABLED=false
-export N8N_SECURE_COOKIE=false
 
 ###########
 ## MAIN  ##


### PR DESCRIPTION
I just re-ordered the custom environment variables part, so that the user can override the inbuilt environment variables.

The reason I need this, is that when I now add Google Calendar credentials, it generates a callback URL that points to "http://localhost:some-port/something", which is obviously using HTTP. But this is not allowed by Google.

So as a user, I'd like to manually override that with my Nabu Casa URL.

I'd love if the Nabu Casa URL could be retrieved programmatically and we could set it automatically, but that doesn't seem to be the case. This will at least allow me to manually set it.