### PR TITLE
Fix ingress issues dealing with external host

### DIFF
--- a/config.json
+++ b/config.json
@@ -31,7 +31,7 @@
   "apparmor": true,
   "options": {
     "timezone": "America/New York",
-    "env_vars_list": ["WEBHOOK_URL=https://hass.pacollier.com/api/hassio_ingress/UiIiYpZUxyGaNniXlZEaU6vXPMPFnmEBKzyePVUIBII"],
+    "env_vars_list": [],
     "cmd_line_args": ""
   },
   "schema": {

--- a/config.json
+++ b/config.json
@@ -30,8 +30,8 @@
   "ingress_port": 8080,
   "apparmor": true,
   "options": {
-    "timezone": "Europe/Berlin",
-    "env_vars_list": [],
+    "timezone": "America/New York",
+    "env_vars_list": ["WEBHOOK_URL=https://hass.pacollier.com/api/hassio_ingress/UiIiYpZUxyGaNniXlZEaU6vXPMPFnmEBKzyePVUIBII"],
     "cmd_line_args": ""
   },
   "schema": {

--- a/export-ingress-variables.sh
+++ b/export-ingress-variables.sh
@@ -18,8 +18,21 @@ else
   export INGRESS_PATH=$(echo "$ADDON_INFO" | jq -r '.data.ingress_url')
   echo "Extracted Ingress Path from Supervisor: ${INGRESS_PATH}"
 
-  # export INGRESS_URL="http://$(echo "$INFO" | jq -r '.data.hostname')"
-  export INGRESS_URL="http://localhost:5678$INGRESS_PATH"
+  # Get the Home Assistant hostname from the supervisor info
+  HA_HOSTNAME=$(echo "$INFO" | jq -r '.data.hostname')
+  
+  # Get the port from the configuration
+  HA_PORT=$(echo "$CONFIG" | jq -r '.port // "8123"')
+  echo "Home Assistant Port: ${HA_PORT}"
+  
+  # Get the external URL if configured, otherwise use the hostname and port
+  EXTERNAL_URL=$(echo "$CONFIG" | jq -r '.external_url // empty')
+  
+  if [ -n "$EXTERNAL_URL" ]; then
+    export INGRESS_URL="${EXTERNAL_URL}${INGRESS_PATH}"
+  else
+    export INGRESS_URL="http://${HA_HOSTNAME}:${HA_PORT}${INGRESS_PATH}"
+  fi
   echo "Extracted Ingress URL from Supervisor: ${INGRESS_URL}"
 fi
 

--- a/n8n-entrypoint.sh
+++ b/n8n-entrypoint.sh
@@ -30,6 +30,9 @@ values=$(jq -r '.env_vars_list | .[]' "$CONFIG_PATH")
 # Convert the values to an array
 IFS=$'\n' read -r -d '' -a array <<< "$values"
 
+# Flag to track if WEBHOOK_URL is set by the user
+webhook_url_set=false
+
 # Export keys and values
 for element in "${array[@]}"
 do
@@ -38,7 +41,18 @@ do
     value=$(echo "$value" | xargs) # Remove leading and trailing whitespace
     export "$key"="$value"
     echo "exported ${key}=${value}"
+    
+    # Check if WEBHOOK_URL is set by the user
+    if [ "$key" = "WEBHOOK_URL" ]; then
+        webhook_url_set=true
+    fi
 done
+
+# If WEBHOOK_URL is not set by the user, set it to the ingress URL
+if [ "$webhook_url_set" = false ]; then
+    export WEBHOOK_URL="${INGRESS_URL}"
+    echo "exported WEBHOOK_URL=${INGRESS_URL} (auto-configured from ingress)"
+fi
 
 # IF NODE_FUNCTION_ALLOW_EXTERNAL is set, install the required packages
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,6 +23,11 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # Add these headers for proper OAuth2 redirects
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Port $server_port;
 
             # WebSocket support
             proxy_http_version 1.1;


### PR DESCRIPTION
This commit resolves an issue where OAuth2 redirects were still using localhost
instead of the proper external URL when WEBHOOK_URL was set. Changes include:

- Update export-ingress-variables.sh to dynamically retrieve Home Assistant hostname
  and port from Supervisor API instead of hardcoding localhost
- Modify n8n-entrypoint.sh to automatically set WEBHOOK_URL to the ingress URL
  when not explicitly configured by the user
- Add proper X-Forwarded headers in nginx.conf to ensure correct URL handling
  for OAuth2 redirects

These changes ensure that OAuth2 callbacks work correctly when accessing n8n
through Home Assistant's ingress system using either the local network or an
external URL.