### PR TITLE
nginx-config: fix connection lost issue

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -24,7 +24,7 @@ http {
 
         location / {
             proxy_pass http://localhost:5678/;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -48,7 +48,7 @@ http {
             # $1 captures the base part (e.g. "webhook") and $2 captures any additional subpath (e.g. "/subpath")
             proxy_pass http://localhost:5678/$1$2;
 
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Replace `proxy_set_header Host $host;` by `.. Host $http_host;` in nginx.conf.

I found a solution in https://github.com/n8n-io/n8n/issues/14392#issuecomment-2789515767 and adopted it for nginx. Seems to work for me.