### PR TITLE
fix: connection lost issue due to websocket invalid origin

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -35,6 +35,9 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
+            proxy_set_header Origin $scheme://$http_host;
+            proxy_cache off;
+            proxy_buffering off;
         }
     }
 
@@ -54,6 +57,9 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Forwarded-Port $server_port;
+            proxy_set_header Origin $scheme://$http_host;
+            proxy_cache off;
+            proxy_buffering off;
         }
 
         location / {


### PR DESCRIPTION
I had time to look into this connection issue after a long time. With the last update(3.4.0), the disconnection problem was still there for me. When I looked deeper, it couldn't connect due to websocket's origin error, so it was getting a 'connection lost' error.

change some parameters in nginx.conf file and its working good in last update.

Here is what I added to nginx configuration:

proxy_set_header Origin $scheme://$http_host
proxy_cache off
proxy_buffering off