### PR TITLE
added Home Assistant Sidebar Icon

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,6 +18,7 @@
   "boot": "auto",
   "icon": "icon.png",
   "logo": "icon.png",
+  "panel_icon": "mdi:sitemap-outline",
   "webui": "http://[HOST]:[PORT:5690]/",
   "map": [
     "ssl:ro",


### PR DESCRIPTION
**added Home Assistant Sidebar Icon:**

`"panel_icon": "mdi:sitemap-outline"`

note: Nodered use `mdi:sitemap` icon so I added `mdi:sitemap-outline` icon for n8n

before: 

![image](https://github.com/user-attachments/assets/bcd0a979-87c1-4c63-9065-7e61b3034ab9)

after adding: 

![image](https://github.com/user-attachments/assets/5bf907e8-c594-4c58-beea-30392716ac40)
