### PR TITLE
 Add /form route to Nginx reverse proxy configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,7 +47,7 @@ http {
         server_name 0.0.0.0;
         listen 8081;
 
-        location ~ ^/(webhook|webhook-test|webhook-waiting|api)(/.*)?$ {
+        location ~ ^/(webhook|webhook-test|webhook-waiting|api|form)(/.*)?$ {
             # $1 captures the base part (e.g. "webhook") and $2 captures any additional subpath (e.g. "/subpath")
             proxy_pass http://localhost:5678/$1$2;
 


### PR DESCRIPTION
 Included `/form` in the Nginx location regex to support routing for form-related requests.
 - This change prevents 404 errors for `/form` on the production URL by ensuring the reverse proxy correctly handles it.
 