### PR TITLE
Update nginx.conf to fix Gmail OAuth2 Error: Insufficient parameters …

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -57,7 +57,7 @@ http {
 
         location ~ ^/(webhook|webhook-test|webhook-waiting|api|form|rest)(/.*)?$ {
             # $1 captures the base part (e.g. "webhook") and $2 captures any additional subpath (e.g. "/subpath")
-            proxy_pass http://localhost:5678/$1$2;
+            proxy_pass http://localhost:5678/$1$2$is_args$args;
 
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
…for OAuth2 callback

After last fix when you try to complete Credentials for Gmail OAuth2 it fails in final part with URL like https://n8n.myhost.xyz/rest/oauth2-credential/callback and you got:

Error: Insufficient parameters for OAuth2 callback. More details
Received following query parameters: {}
Failed to connect. The window can be closed now.

The problem is that urls that Gmail OAuth2 uses have a query string that was being cut out. This fix keeps query string when passing urls to n8n.