### PR TITLE
Fix: Make cmd_line_args usable in n8n entrypoint

### DIFF
--- a/n8n-entrypoint.sh
+++ b/n8n-entrypoint.sh
@@ -9,10 +9,4 @@ echo "WEBHOOK_URL: ${WEBHOOK_URL}"
 ## MAIN  ##
 ###########
 
-if [ "$#" -gt 0 ]; then
-  # Got started with arguments
-  exec n8n "${N8N_CMD_LINE}"
-else
-  # Got started without arguments
-  exec n8n
-fi
+exec n8n $N8N_CMD_LINE


### PR DESCRIPTION
### Problem

The addon reads `cmd_line_args` from `options.json` into `N8N_CMD_LINE`, but the entrypoint never used it because it tested `$#` instead. Since Home Assistant does not pass arguments to the entrypoint, `cmd_line_args` had no effect.

### Solution

Replace the conditional block with a simple:

    exec n8n $N8N_CMD_LINE

- If `N8N_CMD_LINE` is empty, `exec n8n` runs as before.
- If `N8N_CMD_LINE` is set (e.g. "user-management:reset" or "start --tunnel"),
  n8n executes the command with the arguments.

### Result

- `cmd_line_args` is now functional.
- Allows running CLI commands directly from Home Assistant configuration.
- Fully backward compatible: no change when `cmd_line_args` is empty.
