### PR TITLE
chore: publish add-on version 4.2.28

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n",
-  "version": "4.2.27",
+  "version": "4.2.28",
   "slug": "hass-n8n",
   "description": "Self host your n8n instance",
   "url": "https://github.com/Rbillon59/hass-n8n",


### PR DESCRIPTION
## Summary

Updates the Home Assistant add-on metadata version from `4.2.27` to `4.2.28` in `config.json`.

## Why

GitHub release `4.2.28` exists, but Home Assistant reads the add-on version from `config.json` on the repository branch. Since that file still declares `4.2.27`, Home Assistant does not offer users the `4.2.28` update.

## Validation

Checked that the diff is limited to the `config.json` version field.