### PR TITLE
ci: allow manual workflow_dispatch on publish-release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,9 +5,16 @@ permissions: write-all
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to (re)build images for (e.g. v1.2.3)'
+        required: true
+        type: string
 
 jobs:
   update_changelog:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -54,7 +61,7 @@ jobs:
   publish_release:
     runs-on: ubuntu-latest
     env:
-      TAG: ${{ github.event.release.tag_name }}
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
     strategy:
       fail-fast: false
       matrix:
@@ -74,6 +81,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ env.TAG }}
 
     # QEMU lets amd64 runners cross-build arm/arm64 layers
     - uses: docker/setup-qemu-action@v3          


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to `publish-release.yml` with a required `tag` input.
- Skip `update_changelog` on manual runs (`if: github.event_name == 'release'`) — manual dispatch is for rebuilding images, not re-issuing the changelog PR.
- Resolve `TAG` from `github.event.release.tag_name || inputs.tag` so the same job works for both triggers.
- Checkout the resolved tag (`ref: ${{ env.TAG }}`) so manual rebuilds use the tag's tree, not master's HEAD.

## Test plan
- [x] From Actions → "Publish release" → Run workflow → enter an existing tag (e.g. `v1.2.3`) → confirm `update_changelog` is skipped and both arch images are pushed to `ghcr.io/rbillon59/hass-n8n-{amd64,aarch64}:<tag>` and `:latest`.
- [x] Next real release publish still triggers both jobs as before.