### PR TITLE
Add opt-in `unrestrict_file_writes` to allow writes under HA-mapped paths (`/share`, `/media`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ env_vars_list:
   - "EXTERNAL_URL: <value here>"
   - "OTHER_ENVIRONMENT_VARIABLE_OF_YOUR_CHOICE: <value here>"
 cmd_line_args: ""
+unrestrict_file_writes: false
 ```
 
 ## Option: `env_vars_list` (required)
@@ -38,6 +39,16 @@ All the available environment variables are available here : <https://docs.n8n.i
 ## Option: `cmd_line_args` (optional)
 
 The command line to start n8n. If you want to use a custom command line, you can use this variable.
+
+## Option: `unrestrict_file_writes` (optional)
+
+Allows n8n workflows to write files to the Home Assistant mapped directories `/share` and `/media`. Defaults to `false`.
+
+n8n 1.x blocks file writes outside its allowed paths (for example with the Read/Write Files node), even when the OS permissions allow it. The documented workaround, setting the `N8N_BLOCK_FILE_ACCESS_TO_N8N_FILES: "false"` environment variable, does not work in this addon because n8n executes nodes in a task-runner subprocess that receives a stripped environment, so the override never reaches it.
+
+When set to `true`, the addon patches n8n's internal file-system helper (`isFilePathBlocked`) at startup (idempotently) so that file writes are no longer blocked.
+
+**Note:** enabling this removes one of n8n's file-access safety guards, so only enable it if you trust the workflows running in your n8n instance.
 
 ## Installing external packages
 

--- a/config.json
+++ b/config.json
@@ -46,13 +46,15 @@
   "options": {
     "timezone": "Europe/Berlin",
     "env_vars_list": [],
-    "cmd_line_args": ""
+    "cmd_line_args": "",
+    "unrestrict_file_writes": false
   },
   "schema": {
     "timezone": "str",
     "env_vars_list": [
       "match(^[A-Z_0-9]+: .*$)"
     ],
-    "cmd_line_args": "str?"
+    "cmd_line_args": "str?",
+    "unrestrict_file_writes": "bool?"
   }
 }

--- a/n8n-entrypoint.sh
+++ b/n8n-entrypoint.sh
@@ -5,6 +5,23 @@ echo "N8N_PATH: ${N8N_PATH}"
 echo "N8N_EDITOR_BASE_URL: ${N8N_EDITOR_BASE_URL}"
 echo "WEBHOOK_URL: ${WEBHOOK_URL}"
 
+# Optional: relax n8n's file-access guard so file nodes (Read/Write Files,
+# Convert to File, etc.) can write to mapped HA paths like /share and /media.
+# n8n 1.x's `isFilePathBlocked()` defaults block these paths, and the
+# `N8N_BLOCK_FILE_ACCESS_TO_N8N_FILES=false` env override is dropped by the
+# task-runner subprocess that actually executes nodes, so the env-var-only
+# fix is not sufficient. Opt in via the `unrestrict_file_writes: true`
+# addon option (default off — addon ships with upstream defaults preserved).
+if [ "${UNRESTRICT_FILE_WRITES}" = "true" ]; then
+  HELPER=$(find /usr/local/lib/node_modules/n8n -name file-system-helper-functions.js 2>/dev/null | head -1)
+  if [ -n "${HELPER}" ]; then
+    sed -i '/^function isFilePathBlocked/s/{$/{ return false;/' "${HELPER}"
+    echo "unrestrict_file_writes=true: patched isFilePathBlocked in ${HELPER}"
+  else
+    echo "unrestrict_file_writes=true but file-system-helper-functions.js not found; skipping"
+  fi
+fi
+
 ###########
 ## MAIN  ##
 ###########

--- a/n8n-exports.sh
+++ b/n8n-exports.sh
@@ -11,6 +11,7 @@ export N8N_PROTOCOL="$(jq --raw-output '.protocol // empty' $CONFIG_PATH)"
 export N8N_SSL_CERT="/ssl/$(jq --raw-output '.certfile // empty' $CONFIG_PATH)"
 export N8N_SSL_KEY="/ssl/$(jq --raw-output '.keyfile // empty' $CONFIG_PATH)"
 export N8N_CMD_LINE="$(jq --raw-output '.cmd_line_args // empty' $CONFIG_PATH)"
+export UNRESTRICT_FILE_WRITES="$(jq --raw-output '.unrestrict_file_writes // false' $CONFIG_PATH)"
 
 #####################
 ## USER PARAMETERS ##


### PR DESCRIPTION
## Summary

Adds an opt-in addon option, `unrestrict_file_writes` (default `false`), that relaxes n8n's in-process file-access guard so file nodes can write to the HA-mapped paths declared in `config.json` (`share:rw`, `media:rw`). When the option is left at its default, the addon's behavior is unchanged from upstream.

## Motivation

The addon already declares `share:rw` and `media:rw` in its `map`, indicating these paths are intended to be writable from inside the addon. However, the `Read/Write Files` node (and any other node that goes through n8n's `writeContentToFile` / `resolvePath` helpers) fails with:

> `The file "/share/<…>" is not writable.`

even when:

- The host directory is `0777` and owned correctly,
- The addon container runs as root (confirmed via `cat /proc/<n8n-pid>/environ`),
- AppArmor is `docker-default` (no addon-specific profile),
- A direct `node -e \"require('fs').writeFileSync('/share/<…>/x','x')\"` from `docker exec` against the same container succeeds.

This makes the documented `map: [\"share:rw\", \"media:rw\"]` declarations effectively unusable from workflows.

## Root cause

The error is thrown by `isFilePathBlocked()` in `n8n-core`:

```
n8n-core/dist/execution-engine/node-execution-context/utils/file-system-helper-functions.js
```

The documented escape hatch is `N8N_BLOCK_FILE_ACCESS_TO_N8N_FILES=false`. Setting it via the addon's existing `env_vars_list` does reach the main n8n process (PID 8, verified via `/proc/<pid>/environ`). However, n8n 1.x spawns a separate **task-runner subprocess** (`@n8n/task-runner`, started by the main process) that actually executes nodes. That subprocess inherits a stripped environment containing only `N8N_RUNNERS_*` variables — `N8N_BLOCK_FILE_ACCESS_TO_N8N_FILES` is not in the passthrough list — so the override never reaches the process where the check runs.

`N8N_RUNNERS_ENABLED=false` does not fully disable the runner subprocess in current n8n versions, so the env-var path is not sufficient on its own.

## What this PR adds

A single boolean option:

```yaml
# Add-on configuration
unrestrict_file_writes: true
```

When enabled, the entrypoint runs an idempotent `sed` on the helper at startup, neutralizing `isFilePathBlocked()` for this addon image only.

## Defaults & compatibility

- **Default value: `false`.** No existing user is affected unless they explicitly opt in.
- The option is declared `bool?` in the schema, so older `options.json` files without the key validate cleanly.
- The patch is idempotent — the `sed` regex only matches the un-patched line, so re-running the entrypoint multiple times is a no-op.

## Implementation

Three small changes (22 lines added, 2 modified):

- `config.json` — adds the option to `options` and `schema`.
- `n8n-exports.sh` — exports `UNRESTRICT_FILE_WRITES` via `jq` from `/data/options.json`, matching the existing pattern for `cmd_line_args` / `protocol` / etc.
- `n8n-entrypoint.sh` — when `UNRESTRICT_FILE_WRITES=true`, applies the patch before `exec n8n`. When `false` (default), it's a no-op.

## Testing

Per `CONTRIBUTING.md`:

- [x] Webhook triggers — unchanged from upstream (this PR doesn't touch the webhook or HTTP path).
- [x] OAuth2 authentication-based credentials — unchanged (n8n's credential storage paths are not affected).

Additional verification specific to this change:

- [x] With `unrestrict_file_writes: false` (default): addon log shows no patch line; the existing \"not writable\" behavior is preserved for `/share/*` paths.
- [x] With `unrestrict_file_writes: true`: addon log shows `unrestrict_file_writes=true: patched isFilePathBlocked in /usr/local/lib/node_modules/n8n/.../file-system-helper-functions.js`; a Read/Write Files (write) node targeting `/share/<vault>/test.md` succeeds and the file appears on the host.
- [x] Idempotency: restarting the addon repeatedly with the option enabled does not double-patch — the second-run `sed` regex no longer matches.

## Use case

Personal example that motivated this: dropping markdown notes into a Syncthing-replicated Obsidian vault under `/share/obsidian-vault/` so an n8n workflow on the Pi can write directly to the Mac's Obsidian vault. Same shape applies to writing exports, generated reports, or any file-based handoff into the HA `/share` or `/media` directories.