### PR TITLE
ci: auto-merge release-please PRs for zero-touch releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,8 +26,19 @@ jobs:
       pull-requests: write
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
         with:
           # PAT instead of GITHUB_TOKEN so that:
           # - the e2e test workflow runs on the release PR
           # - the published release triggers publish-release.yml
           token: ${{ secrets.CR_PAT }}
+
+      # Zero-touch releases: enable auto-merge on the release PR so it merges
+      # on its own once the e2e checks pass. Merging cuts the tag and publishes
+      # the release, which triggers publish-release.yml.
+      - name: Enable auto-merge on the release PR
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.CR_PAT }}
+          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+        run: gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash


### PR DESCRIPTION
## What this changes

Follow-up to #526. Enables **full-auto releases**: the release PR that release-please keeps open now merges on its own once its e2e checks pass, instead of waiting for a manual merge.

### How

A new step in `release-please.yml` runs only when the action created/updated a release PR (`prs_created == 'true'`) and enables auto-merge (squash) on it via `gh pr merge --auto`. When the e2e checks go green, GitHub merges the PR, which cuts the tag, publishes the GitHub Release, and triggers `publish-release.yml` to build and push the images. `CR_PAT` is used so the merge emits the release event.

### Resulting end-to-end flow (zero-touch)

1. Dependabot bumps the n8n base image with a `fix(deps)` commit.
2. e2e tests pass, dependabot PR auto-merges.
3. release-please opens/updates the `4.2.x` release PR; auto-merge is enabled on it.
4. e2e tests pass on the release PR, it auto-merges, the tag + release are cut.
5. `publish-release.yml` builds and pushes the multi-arch images to ghcr.

### Validation

The release machinery is already proven on the live repo: a manual `workflow_dispatch` of release-please opened #528 (`chore(master): release 4.2.29`) with `config.json`, the manifest, and CHANGELOG.md all correctly bumped, picking up the `fix(deps)` bump from #527. This PR adds the final auto-merge step on top.

Note: the e2e suite occasionally flakes on container startup (#527 needed one rerun), so a release may need a single rerun before it auto-merges. The daily schedule + `concurrency` group from #526 keep the loop self-healing.