### PR TITLE
fix: avoid fromJSON crash when release-please has no PR to create

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,5 +40,5 @@ jobs:
         if: ${{ steps.release.outputs.prs_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.CR_PAT }}
-          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
-        run: gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --squash
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: gh pr merge "$(echo "$PR_JSON" | jq -r '.number')" --repo "$GITHUB_REPOSITORY" --auto --squash


### PR DESCRIPTION
## Bug

The `Enable auto-merge` step added in #529 crashes every time release-please runs with nothing to do (0 releasable commits since the last tag):

```
Error reading JToken from JsonReader. Path '', line 0, position 0.
Line: 43, Col: 22
```

GitHub Actions evaluates `env:` fields **unconditionally** before checking the step `if` condition. When `prs_created` is `false`, `steps.release.outputs.pr` is an empty string, so `${{ fromJSON(steps.release.outputs.pr).number }}` fails immediately.

This has been causing the daily cron to fail since 2026-06-11 (runs 27332277465, 27402331729, 27460356960).

## Fix

Move the JSON parsing out of `env:` and into the `run` shell. The shell only executes when `prs_created == 'true'`, so `jq` never sees an empty string.

```yaml
env:
  PR_JSON: ${{ steps.release.outputs.pr }}
run: gh pr merge "$(echo "$PR_JSON" | jq -r '.number')" ...
```