### PR TITLE
fix: prevent EISDIR crash when N8N_PROTOCOL=https without SSL cert/key

### DIFF
--- a/n8n-exports.sh
+++ b/n8n-exports.sh
@@ -8,8 +8,18 @@ export N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true
 CONFIG_PATH="/data/options.json"
 export GENERIC_TIMEZONE="$(jq --raw-output '.timezone // empty' $CONFIG_PATH)"
 export N8N_PROTOCOL="$(jq --raw-output '.protocol // empty' $CONFIG_PATH)"
-export N8N_SSL_CERT="/ssl/$(jq --raw-output '.certfile // empty' $CONFIG_PATH)"
-export N8N_SSL_KEY="/ssl/$(jq --raw-output '.keyfile // empty' $CONFIG_PATH)"
+
+# Only export the SSL paths when both a certfile and a keyfile are actually
+# configured. Otherwise jq returns empty and the paths collapse to "/ssl/"
+# (the ssl:ro mount directory). When N8N_PROTOCOL=https is also set, n8n then
+# runs readFile() on that directory and crashes with EISDIR. Leaving the vars
+# unset keeps n8n's own empty defaults, so the HTTPS branch is skipped safely.
+N8N_CERTFILE="$(jq --raw-output '.certfile // empty' $CONFIG_PATH)"
+N8N_KEYFILE="$(jq --raw-output '.keyfile // empty' $CONFIG_PATH)"
+if [ -n "$N8N_CERTFILE" ] && [ -n "$N8N_KEYFILE" ]; then
+    export N8N_SSL_CERT="/ssl/$N8N_CERTFILE"
+    export N8N_SSL_KEY="/ssl/$N8N_KEYFILE"
+fi
 export N8N_CMD_LINE="$(jq --raw-output '.cmd_line_args // empty' $CONFIG_PATH)"
 export UNRESTRICT_FILE_WRITES="$(jq --raw-output '.unrestrict_file_writes // false' $CONFIG_PATH)"
 


### PR DESCRIPTION
Fixes #445

## Problem

The add-on fails to start with \`EISDIR: illegal operation on a directory, read\` whenever \`N8N_PROTOCOL: https\` is set in \`env_vars_list\` but no SSL cert/key is configured (a common case behind a reverse proxy or Cloudflare Tunnel, where TLS is terminated upstream).

## Root cause

\`n8n-exports.sh\` unconditionally built the SSL paths:

```sh
export N8N_SSL_CERT="/ssl/$(jq --raw-output ".certfile // empty" $CONFIG_PATH)"
export N8N_SSL_KEY="/ssl/$(jq --raw-output ".keyfile // empty" $CONFIG_PATH)"
```

With no \`certfile\`/\`keyfile\` configured, \`jq\` returns empty, so both vars collapse to literally \`/ssl/\` — the \`ssl:ro\` mount **directory**, not a file.

n8n only reads them when HTTPS is requested (`packages/cli/src/abstract-server.ts`):

```ts
if (protocol === "https" && sslKey && sslCert) {
    key:  await readFile(this.sslKey,  "utf8"),  // readFile("/ssl/") -> EISDIR
    cert: await readFile(this.sslCert, "utf8"),
}
```

Since the paths were non-empty (\`/ssl/\`), n8n entered the HTTPS branch and called \`readFile()\` on a directory, throwing \`EISDIR\`. This is exactly why the add-on boots with an empty \`env_vars_list\` (no \`N8N_PROTOCOL\` -> HTTP branch) but crashes once \`N8N_PROTOCOL: https\` is added.

## Fix

Export \`N8N_SSL_CERT\`/\`N8N_SSL_KEY\` only when **both** \`certfile\` and \`keyfile\` are actually set. Otherwise leave them unset so n8n keeps its own empty defaults and the \`if (sslKey && sslCert)\` guard short-circuits, booting in HTTP as expected.

## Verification

Reproduced the parsing under bash for three cases:

| Config | Before | After |
|---|---|---|
| no certfile/keyfile (issue reporter) | \`N8N_SSL_*=/ssl/\` -> EISDIR | unset -> HTTP boot |
| certfile + keyfile set | \`/ssl/<file>\` | \`/ssl/<file>\` (unchanged) |
| only certfile (incomplete) | \`/ssl/\` -> EISDIR | unset (incomplete pair ignored) |

`bash -n` passes.