### PR TITLE
fix: keep leading slash in N8N_ENDPOINT_HEALTH so editor stays online behind ingress

### DIFF
--- a/n8n-exports.sh
+++ b/n8n-exports.sh
@@ -82,4 +82,12 @@ echo "External Home Assistant n8n URL: ${EXTERNAL_N8N_URL}"
 export N8N_PATH=${N8N_PATH:-"${INGRESS_PATH}"}
 export N8N_EDITOR_BASE_URL=${N8N_EDITOR_BASE_URL:-"${EXTERNAL_N8N_URL}${N8N_PATH}"}
 export WEBHOOK_URL=${WEBHOOK_URL:-"http://${LOCAL_HA_HOSTNAME}:8081"}
-export N8N_ENDPOINT_HEALTH=${N8N_ENDPOINT_HEALTH:-"${INGRESS_PATH#/}healthz"}
+# Keep the leading slash so the path is absolute. Behind the HA ingress, n8n is
+# served under INGRESS_PATH and the ingress does NOT strip that prefix, so the
+# backend must mount the healthz route at "<ingress>/healthz" and the editor must
+# fetch it as an absolute URL. Using "${INGRESS_PATH#/}healthz" dropped the leading
+# slash, which (a) mounts the backend route on a bogus relative path and (b) makes
+# the frontend health check resolve relative to the current page, so it never gets
+# {"status":"ok"} and the editor flips to the "Offline" badge a few seconds after
+# load. "${INGRESS_PATH%/}/healthz" trims a trailing slash then re-adds exactly one.
+export N8N_ENDPOINT_HEALTH=${N8N_ENDPOINT_HEALTH:-"${INGRESS_PATH%/}/healthz"}


### PR DESCRIPTION
Fixes #530

## Symptom

After a recent update, workflows show as **"Offline"** in the editor a few seconds after the page loads, cannot be edited, and new workflows cannot be added. Switching `N8N_PUSH_BACKEND` to `sse` does not help, and the badge text is "Offline" (not "Connection lost").

## Root cause

The health endpoint was built as:

```sh
export N8N_ENDPOINT_HEALTH=${N8N_ENDPOINT_HEALTH:-"${INGRESS_PATH#/}healthz"}
```

`${INGRESS_PATH#/}` strips the **leading** slash, producing a relative path like `api/hassio_ingress/<token>/healthz`.

Behind the HA ingress, n8n is served under `INGRESS_PATH` and the ingress does **not** strip that prefix (which is why the add-on already sets `N8N_PATH=$INGRESS_PATH`). The dropped leading slash then breaks two things:

1. **Backend:** n8n mounts the express healthz route at the raw `N8N_ENDPOINT_HEALTH` value, now a bogus relative path.
2. **Frontend:** recent n8n versions poll the health endpoint from the editor with `fetch(origin + endpointHealth)` and require the response body to be exactly `{"status":"ok"}`. With no leading slash, the URL resolves relative to the current page instead of the root, so the check never gets `{"status":"ok"}`.

When that check fails, n8n flips the editor to the **"Offline"** badge and hides the workflow action buttons. The store defaults to online, so the editor looks fine until the first ~10s health poll fails, matching the "online for a few seconds then offline" report. This is also why `sse` made no difference: the failure is in the health check, not the push transport.

## Fix

Use `${INGRESS_PATH%/}/healthz`: trim a trailing slash, then re-add exactly one leading-anchored `/healthz`. This keeps the path absolute so the backend route and the frontend fetch line up with what arrives through the ingress.

## Verification

```
INGRESS_PATH=[/api/hassio_ingress/tok/] -> [/api/hassio_ingress/tok/healthz]
INGRESS_PATH=[/]                         -> [/healthz]
INGRESS_PATH=[/sub]                      -> [/sub/healthz]
INGRESS_PATH=[/sub/]                     -> [/sub/healthz]
```

No double slash in the `/` (no-ingress) case. `bash -n` passes.