### PR TITLE
fix: remove N8N_ENDPOINT_HEALTH override, let n8n 2.x derive it from N8N_PATH

### DIFF
--- a/n8n-exports.sh
+++ b/n8n-exports.sh
@@ -92,12 +92,3 @@ echo "External Home Assistant n8n URL: ${EXTERNAL_N8N_URL}"
 export N8N_PATH=${N8N_PATH:-"${INGRESS_PATH}"}
 export N8N_EDITOR_BASE_URL=${N8N_EDITOR_BASE_URL:-"${EXTERNAL_N8N_URL}${N8N_PATH}"}
 export WEBHOOK_URL=${WEBHOOK_URL:-"http://${LOCAL_HA_HOSTNAME}:8081"}
-# Keep the leading slash so the path is absolute. Behind the HA ingress, n8n is
-# served under INGRESS_PATH and the ingress does NOT strip that prefix, so the
-# backend must mount the healthz route at "<ingress>/healthz" and the editor must
-# fetch it as an absolute URL. Using "${INGRESS_PATH#/}healthz" dropped the leading
-# slash, which (a) mounts the backend route on a bogus relative path and (b) makes
-# the frontend health check resolve relative to the current page, so it never gets
-# {"status":"ok"} and the editor flips to the "Offline" badge a few seconds after
-# load. "${INGRESS_PATH%/}/healthz" trims a trailing slash then re-adds exactly one.
-export N8N_ENDPOINT_HEALTH=${N8N_ENDPOINT_HEALTH:-"${INGRESS_PATH%/}/healthz"}

--- a/tests/e2e/docker-integration.spec.ts
+++ b/tests/e2e/docker-integration.spec.ts
@@ -84,12 +84,12 @@ test.describe('Docker Container Integration Tests', () => {
   });
 
   test('should return 200 on health endpoint via ingress path', async ({ request }) => {
-    const response = await request.get('http://localhost:5000/api/hassio_ingress/redacted/healthz');
+    const response = await request.get('http://localhost:5000/healthz');
     expect(response.status()).toBe(200);
   });
 
   test('should return valid JSON body from healthz endpoint', async ({ request }) => {
-    const response = await request.get('http://localhost:5000/api/hassio_ingress/redacted/healthz');
+    const response = await request.get('http://localhost:5000/healthz');
     expect(response.status()).toBe(200);
     const contentType = response.headers()['content-type'];
     expect(contentType).toContain('application/json');
@@ -99,14 +99,14 @@ test.describe('Docker Container Integration Tests', () => {
   });
 
   test('should respond to HEAD requests on healthz endpoint', async ({ request }) => {
-    const response = await request.head('http://localhost:5000/api/hassio_ingress/redacted/healthz');
+    const response = await request.head('http://localhost:5000/healthz');
     expect(response.status()).toBe(200);
   });
 
   test('should respond consistently to repeated healthz requests without failures', async ({ request }) => {
     const numRequests = 5;
     for (let i = 0; i < numRequests; i++) {
-      const response = await request.get('http://localhost:5000/api/hassio_ingress/redacted/healthz');
+      const response = await request.get('http://localhost:5000/healthz');
       expect(response.status()).toBe(200);
     }
   });
@@ -117,7 +117,7 @@ test.describe('Docker Container Integration Tests', () => {
 
     // Poll the health endpoint a few times, the same way n8n does internally
     for (let i = 0; i < 3; i++) {
-      const res = await page.request.get('http://localhost:5000/api/hassio_ingress/redacted/healthz');
+      const res = await page.request.get('http://localhost:5000/healthz');
       expect(res.status()).toBe(200);
       await page.waitForTimeout(2000);
     }


### PR DESCRIPTION
## Problem

Issue #530 persists on 4.3.2+ even though PR #535 fixed the leading slash. Users still see the editor stuck on "Offline" with `GET /healthz` returning ~24KB of HTML instead of `{"status":"ok"}`.

## Root cause

In n8n 2.25.7, `N8N_ENDPOINT_HEALTH` affects both:

- `resolveBackendHealthEndpointPath`: mounts the Express health route at that exact path
- `resolveFrontendHealthEndpointPath`: the URL the editor polls every 10s

With `N8N_ENDPOINT_HEALTH=/api/hassio_ingress/<token>/healthz` (set by the addon), n8n mounts the backend route at `/api/hassio_ingress/<token>/healthz`. But the HA ingress **strips its prefix** before forwarding to nginx:5690, so nginx receives `/healthz` and n8n has no handler for it. It falls through to the SPA and returns the full frontend HTML page. The health check never gets `{"status":"ok"}` and the editor stays "Offline".

This was not an issue when the override was introduced in #481 (n8n 2.12.3), where `N8N_ENDPOINT_HEALTH` only controlled the frontend URL, not the backend route.

## Fix

Remove the `N8N_ENDPOINT_HEALTH` override entirely. n8n 2.25.7 handles this correctly without it:

- Backend: mounts on `/healthz` (default)
- Frontend: computes `N8N_PATH + /healthz` = `/api/hassio_ingress/<token>/healthz` for the browser fetch
- HA ingress strips the prefix, nginx receives `/healthz`, n8n responds `{"status":"ok"}`

## Verification

Tested locally with Docker using the existing test fixtures (`tests/supervisor/addon-info.json`, `ingress_url=/api/hassio_ingress/redacted/`):

| Path | Before (master) | After (this PR) |
|---|---|---|
| `GET /healthz` (what nginx receives after ingress strip) | HTML 24KB | `{"status":"ok"}` 15b |
| `GET /api/hassio_ingress/redacted/healthz` | `{"status":"ok"}` 15b | HTML 24KB |

Before: backend route mounted on full ingress path, unreachable after strip.
After: backend route on `/healthz`, matches what the ingress forwards.