### PR TITLE
docs: link to n8n upstream release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Just start the addon and head to the addon's web UI.
 <https://docs.n8n.io>
 <https://docs.n8n.io/getting-started/tutorials.html>
 
+### n8n changelog
+
+This addon's [CHANGELOG.md](CHANGELOG.md) tracks each bump of the underlying `n8nio/n8n` image. For what actually changed in n8n itself (breaking changes on major bumps in particular), check the upstream release notes: <https://docs.n8n.io/release-notes/>
+
 ### Community public workflows
 
 <https://n8n.io/workflows>


### PR DESCRIPTION
Adds a "n8n changelog" section to README.md pointing to n8n's own release notes (https://docs.n8n.io/release-notes/), alongside the existing addon CHANGELOG.md.

Static link, no scripting/regex to maintain. Deep-linking per major bump was considered but would require parsing Dependabot's fixed commit template, not worth the maintenance cost per issue discussion.

Closes #580