### PR TITLE
fix: grant workflows permission for auto-merge on workflow file changes

### DIFF
--- a/.github/workflows/pull-request-change.yaml
+++ b/.github/workflows/pull-request-change.yaml
@@ -3,6 +3,7 @@ name: Build pull request
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 on:
   pull_request:


### PR DESCRIPTION
Squash-merging a PR that touches \`.github/workflows/*\` requires the token performing the merge to have the \`workflows\` scope, GITHUB_TOKEN doesn't have it by default. Without it, the mergePullRequest GraphQL mutation is refused.

This is why the auto-merge step in this same workflow was failing for the Renovate PRs bumping docker/setup-qemu-action, docker/setup-buildx-action, docker/login-action and docker/build-push-action (all used in publish-release.yml), while PRs not touching workflow files merged fine.