### PR TITLE
fix: revert invalid workflows permission key, use CR_PAT for auto-merge

### DIFF
--- a/.github/workflows/pull-request-change.yaml
+++ b/.github/workflows/pull-request-change.yaml
@@ -3,7 +3,6 @@ name: Build pull request
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 on:
   pull_request:
@@ -29,7 +28,7 @@ jobs:
       - name: Enable auto-merge using GitHub CLI
         if: github.actor == 'renovate[bot]'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CR_PAT }}
         run: |
           gh pr merge ${{ github.event.pull_request.number }} \
             --auto \


### PR DESCRIPTION
Urgent fix for #619, which broke CI repo-wide.

\`workflows\` is not a valid GITHUB_TOKEN permission scope, there's no such key in the permissions block schema (confirmed by the "Invalid workflow file ... Unexpected value 'workflows'" error). That made the entire pull-request-change.yaml file unparseable, which is why every push since the #619 merge (19:21:56) has shown a phantom 0-job "failure" run for it, and real pull_request-triggered CI stopped scheduling entirely.

GITHUB_TOKEN can never be granted write access to \`.github/workflows/*\`, no permissions block can change that, it's a hard platform restriction. The actual fix needs a PAT with the \`workflow\` OAuth scope. This repo already has one, \`CR_PAT\`, used by release-please.yml for the same restriction, reusing it here for the auto-merge step.