### PR TITLE
fix: emit n8n bumps as fix so release-please cuts a release

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "packageRules": [
     {
       "matchPackageNames": ["n8nio/n8n"],
+      "semanticCommitType": "fix",
       "commitMessageExtra": "from {{currentVersion}} to {{newVersion}}{{#if hasReleaseNotes}} ([changelog]({{changelogUrl}})){{/if}}"
     }
   ]


### PR DESCRIPTION
## Problem

Since #610 (Dependabot -> Renovate), n8n image bumps land as `chore(deps): update n8nio/n8n docker tag ...` instead of Dependabot's `fix(deps): bump n8nio/n8n ...`. release-please treats `chore` as non-releasable, so #623 (2.36.6) produced no addon release.

## Root cause

The top-level `"semanticCommitType": "fix"` in `renovate.json` never applied.

`config:recommended` extends `:semanticPrefixFixDepsChoreOthers` ([config.preset.ts](https://github.com/renovatebot/renovate/blob/main/lib/config/presets/internal/config.preset.ts)), whose first rule is:

```js
{ matchPackageNames: ['*'], semanticCommitType: 'chore' }
```

packageRules outrank top-level config, so that `chore` wins. The preset restores `fix` only for depTypes `dependencies` / `require` (plus maven and pep621/poetry equivalents). The Dockerfile manager tags its deps `stage` / `final` ([extract.ts](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/dockerfile/extract.ts)), so no `fix` rule matched and every bump fell through to `chore`.

## Fix

Set `semanticCommitType` on the existing `n8nio/n8n` packageRule. Repo-level rules are evaluated after preset rules, so it wins on order.

GitHub Actions bumps stay `chore` on purpose: they do not change the shipped image, so they should not cut an addon release on their own.

`renovate-config-validator` passes on the result.

## Release backlog

Only 2.36.6 (#623) is currently unreleased; 2.36.5 rode along in 4.4.2. This commit is itself a `fix`, so the release it triggers ships the pending bump. No `Release-As` footer needed.

## Test plan

- [x] `npx renovate-config-validator renovate.json` -> `Config validated successfully`
- [ ] release-please cuts 4.4.3 on merge, `config.json` version bumped, image rebuilt with n8n 2.36.6
- [ ] next Renovate n8n PR opens with a `fix(deps):` subject
