### PR TITLE
fix: preserve the browser Origin on the webhook port

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -70,7 +70,9 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Forwarded-Port $server_port;
-            proxy_set_header Origin $scheme://$host;
+            # n8n reflects Origin into Access-Control-Allow-Origin, and $host
+            # drops the port, so a rewritten Origin always fails the CORS check.
+            proxy_set_header Origin $http_origin;
             proxy_cache off;
             proxy_buffering off;
         }

--- a/tests/e2e/nginx-origin-header.spec.ts
+++ b/tests/e2e/nginx-origin-header.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Regressed twice (b0ba6d5, a7556fe) before the CORS breakage was understood.
+const nginxConf = readFileSync(join(__dirname, '..', '..', 'nginx.conf'), 'utf8');
+
+function serverBlock(listenPort: number): string {
+  const start = nginxConf.indexOf(`listen ${listenPort};`);
+  expect(start, `no server block listening on ${listenPort}`).toBeGreaterThan(-1);
+
+  const next = nginxConf.slice(start).search(/\n\s{4}server \{/);
+  return next === -1 ? nginxConf.slice(start) : nginxConf.slice(start, start + next);
+}
+
+test.describe('nginx Origin handling', () => {
+  test('webhook port forwards the browser Origin verbatim', () => {
+    const block = serverBlock(8081);
+
+    expect(block).toContain('proxy_set_header Origin $http_origin;');
+    expect(block).not.toMatch(/proxy_set_header Origin \$scheme:\/\/\$(host|http_host);/);
+  });
+
+  test('ingress port derives Origin and X-Forwarded-Host from the same variable', () => {
+    const block = serverBlock(5690);
+
+    const origin = block.match(/proxy_set_header Origin \$scheme:\/\/(\$\w+);/)?.[1];
+    const forwardedHost = block.match(/proxy_set_header X-Forwarded-Host (\$\w+);/)?.[1];
+
+    expect(origin).toBeDefined();
+    expect(forwardedHost).toBe(origin);
+  });
+});


### PR DESCRIPTION
The 8081 server block overwrote the incoming `Origin` header with `$scheme://$host`, and nginx `$host` strips the port. A browser at `http://192.168.40.1:8123` therefore reached n8n as `http://192.168.40.1`.

n8n reflects the received `Origin` back into `Access-Control-Allow-Origin`, so the reflected value never matched the page origin, the preflight failed, and the call hung with no error. Reported by a user embedding a Chat Trigger in the Home Assistant UI.

Forwarding `$http_origin` passes the real origin verbatim, and omits the header when the client sends none.

Not affected either way: server-to-server webhooks (no `Origin`, so n8n's CORS path never runs) and pages n8n serves itself on 8081 (same-origin).

Two things worth flagging:

- This restores stock n8n CORS behaviour on an exposed port, so preflighted cross-origin calls to `/webhook`, `/form` and `/mcp` now succeed. No `Access-Control-Allow-Credentials` is sent, and per-workflow restriction is available through the trigger node's "Allowed Origins (CORS)" field.
- The 5690 ingress block is deliberately untouched. n8n validates the editor push connection by comparing `Origin` against `X-Forwarded-Host`, and both derive from `$host` there, so they agree. Changing only `Origin` would bring back the "connection lost" bug from b0ba6d5 / a7556fe. The added test locks that invariant.
